### PR TITLE
Fixed Node properties not working correctly

### DIFF
--- a/swift/common/shardtrie.py
+++ b/swift/common/shardtrie.py
@@ -271,7 +271,7 @@ class Node(object):
         return node_dict
 
 
-class ShardTrie():
+class ShardTrie(object):
     """A distributed prefix tree used for managing container shards
 
     Nodes have a timestamp which is used for merging trees.
@@ -495,7 +495,7 @@ class ShardTrie():
         return results
 
 
-class CountingNode():
+class CountingNode(object):
     def __init__(self, key, parent, level, trie=None):
         self._key = key
         self._parent = parent
@@ -561,7 +561,7 @@ class CountingNode():
             return res
 
 
-class CountingTrie():
+class CountingTrie(object):
     """Counting prefix tree (trie)
 
     This trie is a prefix trie, but is solely used to find the best candidate

--- a/swift/common/shardtrie.py
+++ b/swift/common/shardtrie.py
@@ -46,7 +46,7 @@ class ShardTrieException(Exception):
     pass
 
 
-class Node():
+class Node(object):
     def __init__(self, key, parent=None, level=1):
         self._key = key
         self._data = None


### PR DESCRIPTION
Made sharding Node class inherit from object in order to make it new
 style class.

Properties were not working as expected:

``` python
(Pdb) l
401             Places a distributed tree flag and returns the subtree.
402             """
403             node = self.get_node(key)
404             if node:
405                 split_node = node.set_distributed()
406  ->             subTree = ShardTrie(root_node=split_node)
407                 return subTree
408     
409             raise ShardTrieException("Key '%s' not found" % (key))
410     
411         def join_subtrie(self, subtrie, force=False):
(Pdb) p split_node.parent
<swift.common.shardtrie.Node instance at 0x7effa470f950>
(Pdb) p split_node._parent
None
```
