### PR TITLE
Bugfix delete full key

### DIFF
--- a/swift/common/shardtrie.py
+++ b/swift/common/shardtrie.py
@@ -230,8 +230,9 @@ class Node():
             return self.data if full else self.data['data']
 
     def delete(self, key):
-        key_len = len(self.key)
-        if self.key == key:
+        full_key = self.full_key()
+        key_len = len(full_key)
+        if full_key == key:
             if self.children:
                 self.timestamp = Timestamp(time.time()).internal
                 self.data = None
@@ -246,7 +247,7 @@ class Node():
                 self._parent = None
             return True
         elif key_len < len(key):
-            next_key = key[:key_len + 1]
+            next_key = key[:key_len]
             if next_key not in self.children:
                 return False
 


### PR DESCRIPTION
ShardNode.delete currently assumes that node.key is the full key.
edited to use node.full_key()

It may be possible to make this more efficient (reduce full key lookups) by instead at each node:
passing the current level down to the next call of delete
if level == len(key) && self.full_key() == key
as python uses short circuiting, self.full_key() lookup would only be done if at the last recursion (instead of every time)
