### PR TITLE
Bugfix join subtrie

### DIFF
--- a/swift/common/shardtrie.py
+++ b/swift/common/shardtrie.py
@@ -416,7 +416,7 @@ class ShardTrie():
         node = self.get_node(key)
         if node:
             if node.is_distributed() or force:
-                new_key = subtrie.root[-1]
+                new_key = subtrie.root_key[-1]
                 node.parent.children[new_key] = subtrie.root
                 subtrie.root.key = new_key
                 subtrie.root.parent = node.parent


### PR DESCRIPTION
join_subtrie was trying to use array access on a node value in order to get the name for a new node. This has been changed to access the last character in full_key instead.
