### PR TITLE
Made Node.delete more efficient

### DIFF
--- a/swift/common/shardtrie.py
+++ b/swift/common/shardtrie.py
@@ -230,9 +230,10 @@ class Node(object):
             return self.data if full else self.data['data']
 
     def delete(self, key):
-        full_key = self.full_key()
-        key_len = len(full_key)
-        if full_key == key:
+        trie_depth = self.level - 1
+        # Python short circuits comparisons. Thus the full key is only looked
+        #  up when likely at the node to delete
+        if trie_depth == len(key) and key == self.full_key():
             if self.children:
                 self.timestamp = Timestamp(time.time()).internal
                 self.data = None
@@ -246,8 +247,8 @@ class Node(object):
                 self.children = None
                 self._parent = None
             return True
-        elif key_len < len(key):
-            next_key = key[:key_len]
+        elif trie_depth < len(key):
+            next_key = key[trie_depth]
             if next_key not in self.children:
                 return False
 

--- a/test/unit/common/test_shardtrie.py
+++ b/test/unit/common/test_shardtrie.py
@@ -159,6 +159,11 @@ class TestShardTrie(unittest.TestCase):
         self.assertTrue(trie.delete('abc'))
         self.assertEqual(trie.root.count_data_nodes(), number_data_nodes - 1)
 
+        # Delete a node on a distributed branch
+        subtrie = trie.split_trie('ab')
+        self.assertFalse(trie.delete('abd'))
+        self.assertTrue(subtrie.delete('abd'))
+
     def test_shardtrie_add(self):
         """Test adding a node to the shardtrie"""
         trie = self.trie


### PR DESCRIPTION
Replaced full key lookup logic with node depth logic.
Now only looks up the key if at the last node
example time difference with key of length 300:
original: 0:00:00.020698
new     : 0:00:00.000432
