### PR TITLE
Fix get_all_shard_nodes_since ignoring timestamp

### DIFF
--- a/swift/container/backend.py
+++ b/swift/container/backend.py
@@ -1082,7 +1082,7 @@ class ContainerBroker(DatabaseBroker):
             try:
                 sql = 'SELECT name, created_at, flag, deleted '
                 sql += 'FROM shard_nodes '
-                sql += 'WHERE created_at >= %s ' % timestamp \
+                sql += 'WHERE created_at >= "%s" ' % timestamp \
                     if timestamp else ''
                 sql += 'ORDER BY ROWID ASC'
                 sql += 'LIMIT %d' % limit if limit else ''


### PR DESCRIPTION
get_all_shard_nodes was not quoting the given timestamp and thus it was ignored when the sqlite statement was evaluated.

Test before edit:

```
dev@dev:~/swift-blm$ python test/unit/container/test_backend.py
..............F.................................F.................................F..................................F...............................................
======================================================================
FAIL: test_all_shard_nodes_since (__main__.TestContainerBroker)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/unit/container/test_backend.py", line 1480, in test_all_shard_nodes_since
    self.assertEqual(['c', 'd', 'e', 'ef'], nodes_since_3)
AssertionError: Lists differ: ['c', 'd', 'e', 'ef'] != []

First list contains 4 additional elements.
First extra element 0:
c

- ['c', 'd', 'e', 'ef']
+ []
```

After:

```
dev@dev-VirtualBox:~/swift-blm$ python test/unit/container/test_backend.py
.....................................................................................................................................................................
----------------------------------------------------------------------
Ran 165 tests in 4.509s

OK
```
