### PR TITLE
Fixed bounds function ignoring pivots 

### DIFF
--- a/swift/common/utils.py
+++ b/swift/common/utils.py
@@ -3709,10 +3709,16 @@ class PivotTree(object):
           ('f', 'l')
 
         That is to say, anything > 'f' and < 'l'
+        Note: None represets either -inf or +inf depending on the side it is
+
+        These bounds are with respect to the level of the pivot. That is, a
+        pivot contains all the elements of its lower pivots. Hence, the root
+        pivot will always return (None, None) because it contains all the
+        elements in the container.
 
         :rtype : object
         """
-        pivot, weight = self.get(pivot)
+        pivot, weight = self.get(pivot, leaf=False)
         gt = lt = None
 
         if pivot is None or pivot.parent is None:

--- a/test/unit/common/test_utils.py
+++ b/test/unit/common/test_utils.py
@@ -4983,5 +4983,48 @@ class TestPairs(unittest.TestCase):
                               (50, 60)]))
 
 
+class TestPivotTree(unittest.TestCase):
+    def _build_tree(self, *args):
+        tree = utils.PivotTree()
+        for node in args:
+            tree.add(node)
+        return tree
+
+    def test_bounds(self):
+        #   c
+        #  b d
+        #     e
+        tree = self._build_tree('c', 'b', 'd','e')
+        bounds = tree.get_pivot_bounds('e')
+        self.assertEqual(bounds, ('d', None))
+        bounds = tree.get_pivot_bounds('d')
+        self.assertEqual(bounds, ('c', None))
+
+        #   d
+        #  c e
+        # b
+        tree = self._build_tree('d', 'c', 'b','e')
+        bounds = tree.get_pivot_bounds('b')
+        self.assertEqual(bounds, (None, 'c'))
+        bounds = tree.get_pivot_bounds('c')
+        self.assertEqual(bounds, (None, 'd'))
+
+        #   c
+        #  b
+        tree = self._build_tree('c', 'b')
+        bounds = tree.get_pivot_bounds('b')
+        self.assertEqual(bounds, (None, 'c'))
+        bounds = tree.get_pivot_bounds('c')
+        self.assertEqual(bounds, (None, None))
+
+        #   b
+        #    c
+        tree = self._build_tree('b', 'c')
+        bounds = tree.get_pivot_bounds('c')
+        self.assertEqual(bounds, ('b', None))
+        bounds = tree.get_pivot_bounds('b')
+        self.assertEqual(bounds, (None, None))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When acting upon a container of the following layout

```
   piv1
   /
piv2
```

where only 1 of the two containers for the pivot is sharded,
The bounds function, when called on piv1, will use piv2 as
the pivot for determining bounds. This will cause gt.piv1
misplaced_objects query to include all objects before
and all objects after its pivot, thus dropping all objects
in the container.
