### PR TITLE
Fix rsync_then_merge not merging other items

### DIFF
--- a/swift/common/db_replicator.py
+++ b/swift/common/db_replicator.py
@@ -808,7 +808,7 @@ class ReplicatorRpc(object):
             sleep()
         # Note the following hook will need to change to using a pointer and
         # limit in the future.
-        other_items = self._other_items_hook(new_broker)
+        other_items = self._other_items_hook(existing_broker)
         if other_items:
             new_broker.merge_items(other_items)
         new_broker.newid(args[0])


### PR DESCRIPTION
Inconsistently, merging a pivot node back to the root
container would result in all the existing pivots being
lost and only the newest pivot remaining. This was found
to be due to merging the handoff's table back into the
handoff rather than from the actual table into the
handoff.
